### PR TITLE
Add centralized Slack notifier via /api/notify-lead

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { notifyLead, utmFromLocation } from '@/lib/notifyLead';
 import { Button, Card, Input, Container } from '@/components/ui';
 import { colors, typography, spacing } from '@/styles/design-system';
 
@@ -12,6 +13,14 @@ export default function Home() {
     e.preventDefault();
     // TODO: Submit to API
     console.log('Email submitted:', email);
+    // Fire-and-forget Slack notifier for consultation interest
+    try {
+      const page_url = typeof window !== 'undefined' ? window.location.href : '';
+      const payload = { email, page_url, ...utmFromLocation() };
+      notifyLead('consultation', payload);
+    } catch (e) {
+      console.warn('notifyLead skipped', e);
+    }
   };
 
   return (

--- a/frontend/src/lib/notifyLead.ts
+++ b/frontend/src/lib/notifyLead.ts
@@ -1,0 +1,24 @@
+export function utmFromLocation() {
+  if (typeof window === 'undefined') return {} as Record<string, string>;
+  const q = new URLSearchParams(window.location.search);
+  return {
+    utm_source: q.get('utm_source') || '',
+    utm_medium: q.get('utm_medium') || '',
+    utm_campaign: q.get('utm_campaign') || '',
+    utm_term: q.get('utm_term') || '',
+    utm_content: q.get('utm_content') || '',
+  } as Record<string, string>;
+}
+
+export async function notifyLead(context: string, payload: Record<string, any>) {
+  try {
+    await fetch('https://utlyzecom.vercel.app/api/notify-lead', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ context, payload }),
+    });
+  } catch (e) {
+    console.warn('notifyLead failed', e);
+  }
+}
+


### PR DESCRIPTION
This PR adds a fire-and-forget Slack notifier that posts to our centralized endpoint (utlyzecom.vercel.app/api/notify-lead). It sends relevant form payload + page_url + UTM, without blocking UX. After utlyze.com is reattached, we can switch endpoint to utlyze.com/api/notify-lead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Captures UTM parameters from the page URL during email/consultation signup to improve attribution.
  - Sends a background notification when users submit their email, including page URL and UTM details, aiding timely follow-ups.
  - Designed to be non-blocking and safe in all rendering contexts, with graceful error handling.

- Chores
  - Introduced a small utility to parse UTM parameters and handle lead notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->